### PR TITLE
fix: iterate over all possible errors when end_mode='all'

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         entry: "conform enforce"
         pass_filenames: false
   - repo: "https://github.com/trufflesecurity/trufflehog"
-    rev: "0f58ae7c5036094a1e3e750d18772af92821b503"  # frozen: v3.90.5
+    rev: "18c7b1fc33e6c16b27ea66ff27cc7e642fb7cd0a"  # frozen: v3.90.6
     hooks:
       - id: "trufflehog"
         alias: "secrets"

--- a/src/lintkit/_run.py
+++ b/src/lintkit/_run.py
@@ -114,7 +114,11 @@ def run(  # noqa: PLR0913
     if output:
         return generator_or_callable
     # Exhaust iterator and return whether any rule raised an error
-    return any(result[0] for result in generator_or_callable)
+    errored = False
+    for result in generator_or_callable:
+        if result[0]:
+            errored = True
+    return errored
 
 
 def _run(  # noqa: C901, PLR0912
@@ -158,7 +162,9 @@ def _run(  # noqa: C901, PLR0912
         path = pathlib.Path(file)
 
         output = _load(path, warn)
-        if output is None:
+
+        # This error may not be raised depending on the files being read
+        if output is None:  # pragma: no cover
             continue
 
         lines, content = output
@@ -216,7 +222,8 @@ def _load(
     """
     try:
         return _read(path)
-    except UnicodeDecodeError as _:
+    # This error may not be raised depending on the files being read
+    except UnicodeDecodeError as _:  # pragma: no cover
         if warn:  # pragma: no cover
             warnings.warn(
                 f"File '{path}' could not be loaded.",

--- a/src/lintkit/cli/_main.py
+++ b/src/lintkit/cli/_main.py
@@ -20,7 +20,7 @@ if typing.TYPE_CHECKING:
 
 def main(  # noqa: PLR0913
     version: str,
-    files_default: Iterable[str | pathlib.Path] | None = None,
+    files_default: Iterable[str | pathlib.Path],
     files_help: str | None = None,
     include_codes: Iterable[int] | None = None,
     exclude_codes: Iterable[int] | None = None,

--- a/src/lintkit/cli/_parser.py
+++ b/src/lintkit/cli/_parser.py
@@ -18,7 +18,7 @@ if typing.TYPE_CHECKING:
 
 def root(
     version: str,
-    files_default: Iterable[str | pathlib.Path] | None = None,
+    files_default: Iterable[str | pathlib.Path],
     files_help: str | None = None,
     **kwargs: typing.Any,
 ) -> argparse.ArgumentParser:
@@ -64,7 +64,7 @@ def root(
 
 def _check(
     subparsers,  # noqa: ANN001  # pyright: ignore [reportUnknownParameterType, reportMissingParameterType]
-    default: Iterable[str | pathlib.Path] | None,
+    default: Iterable[str | pathlib.Path],
     help_: str | None,
 ) -> None:
     """Create `check` subcommand subparser.
@@ -96,12 +96,6 @@ def _check(
         """),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    if default is None:
-        default = (
-            p
-            for p in pathlib.Path().rglob("*")
-            if p.is_file() and ".git" not in str(p)
-        )
     if help_ is None:
         help_ = "Files to process (default: all files in current working directory, recursively)"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,10 +18,6 @@ if typing.TYPE_CHECKING:
     from collections.abc import Iterable
 
 
-@pytest.mark.parametrize(
-    "files_default",
-    ((p for p in pathlib.Path().rglob("*.py")), None),
-)
 @pytest.mark.parametrize("files_help", ("Go over files", None))
 @pytest.mark.parametrize("include_codes", ([1, 2, 3], None))
 @pytest.mark.parametrize("exclude_codes", ([1, 2, 3], None))
@@ -34,8 +30,7 @@ if typing.TYPE_CHECKING:
         ["rules"],
     ),
 )
-def test_smoke(  # noqa: PLR0913
-    files_default: Iterable[pathlib.Path | str],
+def test_smoke(
     files_help: str | None,
     include_codes: Iterable[int] | None,
     exclude_codes: Iterable[int] | None,
@@ -68,7 +63,11 @@ def test_smoke(  # noqa: PLR0913
     try:
         lintkit.cli.main(
             version="0.0.1",
-            files_default=files_default,
+            # Used to only process tests files, not everything,
+            # excluding things like __pypackages__ etc.
+            files_default=(
+                p for p in pathlib.Path().glob("./tests/**") if p.is_file()
+            ),
             files_help=files_help,
             include_codes=include_codes,
             exclude_codes=exclude_codes,


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2025 open-nudge <https://github.com/open-nudge>
SPDX-FileContributor: szymonmaszke <github@maszke.co>

SPDX-License-Identifier: Apache-2.0
-->

<!--- pyml disable-next-line first-line-heading,first-line-h1-->

## Checklist

- [x] I agree to follow this project's [Code of Conduct](https://github.com/open-nudge/lintkit/blob/main/CODE_OF_CONDUCT.md)
- [x] I have read this project's [Contributing Guide](https://github.com/open-nudge/lintkit/blob/main/CONTRIBUTING.md)
- [x] I have created relevant issue(s) and linked them in the PR description

> Closes #8 
