### PR TITLE
fix: return 0 or 1 exit code properly instead of bool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         name: "<<<CHECK>>> Secrets"
         verbose: true
   - repo: "https://github.com/google/osv-scanner/"
-    rev: "16ed4529c0d0cc1ddf1bed2fb08deba187339673"  # frozen: v2.2.2
+    rev: "a66ef4bd60622d94e536ee3ee5592ea1e3e9a382"  # frozen: v2.2.3
     hooks:
       - id: "osv-scanner"
         name: "<<<CHECK>>> OSV Scanner"

--- a/src/lintkit/cli/_subcommand.py
+++ b/src/lintkit/cli/_subcommand.py
@@ -45,12 +45,14 @@ def check(
 
     """
     sys.exit(
-        _run.run(  # pyright: ignore[reportArgumentType]
-            args.files,
-            include_codes,
-            exclude_codes,
-            end_mode,
-            output=False,
+        int(
+            _run.run(  # pyright: ignore[reportArgumentType]
+                args.files,
+                include_codes,
+                exclude_codes,
+                end_mode,
+                output=False,
+            )
         )
     )
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2025 open-nudge <https://github.com/open-nudge>
SPDX-FileContributor: szymonmaszke <github@maszke.co>

SPDX-License-Identifier: Apache-2.0
-->

<!--- pyml disable-next-line first-line-heading,first-line-h1-->

## Checklist

- [x] I agree to follow this project's [Code of Conduct](https://github.com/open-nudge/lintkit/blob/main/CODE_OF_CONDUCT.md)
- [x] I have read this project's [Contributing Guide](https://github.com/open-nudge/lintkit/blob/main/CONTRIBUTING.md)
- [x] I have created relevant issue(s) and linked them in the PR description

> Closes #13 