### PR TITLE
fix: match only exact rule number

### DIFF
--- a/src/lintkit/settings.py
+++ b/src/lintkit/settings.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 open-nudge <https://github.com/open-nudge>
+# SPDX-FileCopyrightText: © 2025, 2026 open-nudge <https://github.com/open-nudge>
 # SPDX-FileContributor: szymonmaszke <github@maszke.co>
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -113,7 +113,7 @@ Tip:
 
 """
 
-ignore_line: str = ".* noqa: .*{name}{code}.*"
+ignore_line: str = ".* noqa: .*{name}{code}(?!\\d).*"
 """The regex pattern registering a line to be ignored.
 
 Note:
@@ -122,7 +122,7 @@ Note:
     ```# noqa: E123, E456``` or ```# noqa: E123 E456 E789```.
 """
 
-ignore_file: str = ".* noqa-file: [^\n]*{name}{code}.*[^\n]*"
+ignore_file: str = ".* noqa-file: [^\n]*{name}{code}(?!\\d).*[^\n]*"
 """The regex pattern indicating the error should be ignored in the whole file.
 
 Note:
@@ -131,7 +131,7 @@ Note:
     ```# noqa-file: E123, E456``` or ```# noqa-file: E123 E456 E789```.
 """
 
-ignore_span_start: str = ".* noqa-start: .*{name}{code}.*"
+ignore_span_start: str = ".* noqa-start: .*{name}{code}(?!\\d).*"
 """The regex pattern registering start of ignoring.
 
 Warning:
@@ -144,7 +144,7 @@ Note:
     ```# noqa: E123, E456``` or ```# noqa: E123 E456 E789```.
 """
 
-ignore_span_end: str = ".* noqa-end: .*{name}{code}.*"
+ignore_span_end: str = ".* noqa-end: .*{name}{code}(?!\\d).*"
 """The regex pattern registering a line to be ignored.
 
 Warning:

--- a/tests/test_noqa.py
+++ b/tests/test_noqa.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 open-nudge <https://github.com/open-nudge>
+# SPDX-FileCopyrightText: © 2025, 2026 open-nudge <https://github.com/open-nudge>
 # SPDX-FileContributor: szymonmaszke <github@maszke.co>
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -19,10 +19,9 @@ Warning:
 
 from __future__ import annotations
 
-import typing
+import re
 
-if typing.TYPE_CHECKING:
-    import pytest
+import pytest
 
 import lintkit
 
@@ -44,6 +43,31 @@ def miss3() -> None:
 
 
 # noqa-end: TEST2, TEST1, TEST0
+
+
+@pytest.mark.parametrize(
+    ("pattern", "ignore"),
+    (
+        (lintkit.settings.ignore_line, "# noqa: RULE4"),
+        (lintkit.settings.ignore_file, "# noqa-file: RULE4"),
+        (lintkit.settings.ignore_span_start, "# noqa-start: RULE4"),
+        (lintkit.settings.ignore_span_end, "# noqa-end: RULE4"),
+    ),
+)
+def test_numeric_boundary(pattern: str, ignore: str) -> None:
+    """Ensure ignore patterns distinguish numeric rule suffixes.
+
+    Args:
+        pattern:
+            Public ignore pattern to test.
+        ignore:
+            Exact ignore text for rule 4.
+
+    """
+    regex = pattern.format(name="RULE", code=4)
+
+    assert re.search(regex, ignore) is not None
+    assert re.search(regex, f"{ignore}3") is None
 
 
 def test_noqa(


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2025 open-nudge <https://github.com/open-nudge>
SPDX-FileContributor: szymonmaszke <github@maszke.co>

SPDX-License-Identifier: Apache-2.0
-->

<!--- pyml disable-next-line first-line-heading,first-line-h1-->

## Checklist

- [x] I agree to follow this project's [Code of Conduct](https://github.com/open-nudge/lintkit/blob/main/CODE_OF_CONDUCT.md)
- [x] I have read this project's [Contributing Guide](https://github.com/open-nudge/lintkit/blob/main/CONTRIBUTING.md)
- [x] I have created relevant issue(s) and linked them in the PR description

> Closes #21 
