### PR TITLE
feat!: split rule prefix and tool name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         entry: "conform enforce"
         pass_filenames: false
   - repo: "https://github.com/trufflesecurity/trufflehog"
-    rev: "20652fbbdefffcdaa493a5bf57ab2ac6b1db715b"  # frozen: v3.97.1
+    rev: "363923b901c911a9164f50b6c423f47c15372b1c"  # frozen: v3.97.4
     hooks:
       - id: "trufflehog"
         alias: "secrets"
@@ -50,7 +50,7 @@ repos:
           - "--licenses=MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,Unlicense,Zlib,OFL-1.1,0BSD,PSF-2.0"
           - "./"
   - repo: "https://github.com/errata-ai/vale"
-    rev: "405a7dabd73651d8ba24c72767a70c065aa6716a"  # frozen: v3.19.0
+    rev: "fdc4cc754f58d953f668586dc1891064a746e0a2"  # frozen: v3.20.0
     hooks:
       - id: "vale"
         alias: "setup-natural-language"
@@ -62,7 +62,7 @@ repos:
         stages:
           - "pre-commit"
   - repo: "https://github.com/errata-ai/vale"
-    rev: "405a7dabd73651d8ba24c72767a70c065aa6716a"  # frozen: v3.19.0
+    rev: "fdc4cc754f58d953f668586dc1891064a746e0a2"  # frozen: v3.20.0
     hooks:
       - id: "vale"
         alias: "natural-language"

--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ __two rules__ and running it on three files:
 ```python
 import lintkit
 
-# Set the name of the linter
-lintkit.settings.name = "NOUTILS"
+# Set the application identity and public rule prefix
+lintkit.settings.name.tool = "noutils"
+lintkit.settings.name.rule = "NOUTILS"
 
 
 class _NoUtils(lintkit.check.Regex, lintkit.loader.Python, lintkit.rule.Node):

--- a/docs/tutorials/advanced.md
+++ b/docs/tutorials/advanced.md
@@ -47,8 +47,16 @@ most of the building blocks by now.
 
 Let's start with `check`ers definitions:
 
+Set both identities before any concrete rule subclasses are defined.
+The lowercase `.tool` value is the tool name,
+`.rule` value is the prefix for rules (used by noqa and settings).
+
 ```python
 import lintkit
+
+# Define both identities before defining concrete rules
+lintkit.settings.name.tool = "my-advanced-linter"
+lintkit.settings.name.rule = "MY-ADVANCED-LINTER"
 
 
 # abstract because we will have to define `regex` method
@@ -208,9 +216,6 @@ import lintkit
 
 # Assuming this is where the rules were defined
 import rules
-
-# Defining linter name here is also fine
-lintkit.settings.name: str = "MY-ADVANCED-LINTER"
 
 if __name__ == "__main__":
     sys.exit(lintkit.run(pathlib.Path(".").rglob("*.py")))

--- a/docs/tutorials/basic.md
+++ b/docs/tutorials/basic.md
@@ -25,8 +25,9 @@ import lintkit
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable
 
-# Define the name for our linter
-lintkit.settings.name = "MYLINTER"
+# Define the application identity and public rule prefix
+lintkit.settings.name.tool = "mylinter"
+lintkit.settings.name.rule = "MYLINTER"
 
 
 class NameDefined(lintkit.loader.TOML, lintkit.rule.Node, code=1):
@@ -65,9 +66,10 @@ class NameDefined(lintkit.loader.TOML, lintkit.rule.Node, code=1):
 
 Please note the following elements:
 
-- [`lintkit.settings.name`][] attribute specifies the name our
-    linter will have (used when outputting errors or defining
-    in-code ignores).
+- [`lintkit.settings.name.tool`][] - name of the linter and its
+    configuration namespace.
+- [`lintkit.settings.name.rule`][] - rule case-sensitive prefix used
+    for diagnostics, `noqa` ignores.
 - [`lintkit.loader.TOML`][] will load `toml` file __and__
     save it as a state under `data`
 - Access to `loader` created attributes should __always__ be performed by
@@ -77,7 +79,7 @@ Please note the following elements:
     all `TOML` files). Check out [File linters](file.md) for more information.
 - `code=1` specifies __numeric value associated with this rule__.
     It will later be displayed as a concatenation of
-    [`lintkit.settings.name`][] and `code`, in our case
+    [`lintkit.settings.name.rule`][] and `code`, in our case
     `"MYLINTER1"`. Many linters have their own codes (or group of codes),
     for example [`ruff`](https://docs.astral.sh/ruff/rules/).
 - One has to define
@@ -157,8 +159,9 @@ import lintkit
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable
 
-# Define the name for our linter
-lintkit.settings.name = "MYLINTER"
+# Define both identities before defining concrete rules
+lintkit.settings.name.tool = "mylinter"
+lintkit.settings.name.rule = "MYLINTER"
 
 
 class PyProjectNameLoader(lintkit.loader.TOML, lintkit.rule.Node):

--- a/docs/tutorials/configure.md
+++ b/docs/tutorials/configure.md
@@ -71,6 +71,10 @@ include_codes = [4]
 max_name_length = 5
 ```
 
+The root table name `mylinter` is the same as `lintkit.settings.name.tool`.
+The nested rule table name `MYLINTER4` is the `lintkit.settings.name.rule`
+value followed by numeric code `4`.
+
 ## Load config
 
 Lintkit can use [`loadfig`](https://github.com/open-nudge/loadfig) to load the
@@ -98,7 +102,7 @@ import rules
 
 
 def main() -> None:
-    # Loads [tool.mylinter], based on lowercase lintkit.settings.name
+    # Loads [tool.mylinter] based on settings.name.tool
     config = lintkit.config()
 
     # Run the linter with code inclusions and exclusions
@@ -118,9 +122,11 @@ if __name__ == "__main__":
 Things you should note:
 
 - `Rule.config()` reads only the nested table matching that rule's exact public
-    name, such as `[tool.mylinter.MYLINTER4]`
+    name from `settings.name.rule` plus its code, such as
+    `[tool.mylinter.MYLINTER4]`
 - \[`lintkit.config`\][] returns the whole `[tool.mylinter]` table for shared
-    options such as rule selection
+    options such as rule selection; the root table comes from the lowercase
+    form of `settings.name.tool`
 - \[`lintkit.registry.inject`\][] remains available for unrelated custom
     resources that should be shared by __all rules__
 - \[`lintkit.run`\][] gives you more flexibility (e.g.

--- a/docs/tutorials/file.md
+++ b/docs/tutorials/file.md
@@ -82,7 +82,8 @@ import itertools
 
 import lintkit
 
-lintkit.settings.name: str = "FILELINTER"
+lintkit.settings.name.tool = "filelinter"
+lintkit.settings.name.rule = "FILELINTER"
 
 
 # You might not inherit from `check.Check` as long as you fulfil the interface
@@ -168,7 +169,8 @@ import ast
 
 import lintkit
 
-lintkit.settings.name: str = "ALLLINTER"
+lintkit.settings.name.tool = "alllinter"
+lintkit.settings.name.rule = "ALLLINTER"
 
 
 class TooManyConditionals(lintkit.loader.Python, lintkit.rule.All, code=0):

--- a/docs/tutorials/mcp.md
+++ b/docs/tutorials/mcp.md
@@ -31,7 +31,8 @@ properties:
 - each tool has one `names` selector
 - values must be exact, case-sensitive full names,
     such as `MYLINTER10`; names are not uppercased and the choices
-    are properly typed as `typing.Literal`
+    are properly typed as `typing.Literal`. These identifiers use
+    `lintkit.settings.name.rule` for typing
 - `check` accepts explicit `files`; under `lintkit mcp`, omitting them uses the
     defaults configured by the linter's `lintkit.cli.main` call
     (we advise to use a recursive one)
@@ -58,8 +59,9 @@ Repeat `--allowed-host` and `--allowed-origin` to add values. Use
 stateless unless you add the legacy (since 2026-07-06 specification)
 `--stateful` option.
 
-Use `--name` to replace the default server name, which is the same as linter's
-name by default (different from randomly generated default of `fastmcp`):
+Use `--name` to replace the default server name, which is
+`lintkit.settings.name.tool` by default (different from the randomly generated
+default of `fastmcp`).
 
 ```sh
 > lintkit mcp --name "Project linter"

--- a/src/lintkit/_config.py
+++ b/src/lintkit/_config.py
@@ -23,4 +23,4 @@ def config() -> dict[typing.Any, typing.Any]:
         finds no configuration.
 
     """
-    return loadfig.config(settings._name().lower())  # noqa: SLF001
+    return loadfig.config(settings._name("tool").lower())  # noqa: SLF001

--- a/src/lintkit/_ignore.py
+++ b/src/lintkit/_ignore.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 open-nudge <https://github.com/open-nudge>
+# SPDX-FileCopyrightText: © 2025, 2026 open-nudge <https://github.com/open-nudge>
 # SPDX-FileContributor: szymonmaszke <github@maszke.co>
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -77,7 +77,10 @@ def file(rule: Rule, content: str) -> bool:
     """
     return (
         re.search(
-            settings.ignore_file.format(name=settings.name, code=rule.code),
+            settings.ignore_file.format(
+                name=settings._name("rule"),  # noqa: SLF001
+                code=rule.code,
+            ),
             content,
         )
         is not None
@@ -109,10 +112,16 @@ def spans(file: pathlib.Path, rule: Rule, lines: list[str]) -> Iterator[Span]:
 
     """
     start_regex = re.compile(
-        settings.ignore_span_start.format(name=settings.name, code=rule.code)
+        settings.ignore_span_start.format(
+            name=settings._name("rule"),  # noqa: SLF001
+            code=rule.code,
+        )
     )
     end_regex = re.compile(
-        settings.ignore_span_end.format(name=settings.name, code=rule.code)
+        settings.ignore_span_end.format(
+            name=settings._name("rule"),  # noqa: SLF001
+            code=rule.code,
+        )
     )
 
     start = None

--- a/src/lintkit/cli/_parser.py
+++ b/src/lintkit/cli/_parser.py
@@ -199,8 +199,8 @@ def _mcp(subparsers: argparse._SubParsersAction[_RootParser]) -> None:
     )
     _ = parser.add_argument(
         "--name",
-        default=settings._name(),  # noqa: SLF001
-        help="Server name (default: linter name).",
+        default=settings._name("tool"),  # noqa: SLF001
+        help="Server name (default: tool name).",
     )
     _ = parser.add_argument(
         "--transport",
@@ -242,7 +242,8 @@ def _selectors(parser: argparse.ArgumentParser) -> None:
             Subcommand parser to update.
 
     """
-    names = tuple(f"{settings._name()}{code}" for code in registry.codes())  # noqa: SLF001
+    rule_name = settings._name("rule")  # noqa: SLF001
+    names = tuple(f"{rule_name}{code}" for code in registry.codes())
     _ = parser.add_argument(
         "--names",
         nargs="*",

--- a/src/lintkit/cli/_subcommand.py
+++ b/src/lintkit/cli/_subcommand.py
@@ -66,7 +66,10 @@ def rules(names: Iterable[str] | None = None) -> str:
     header = ("Name", "Description")
     rows: list[tuple[str, str]] = [header]
     rows.extend(
-        (f"{settings._name()}{code}", registered[code].description())  # noqa: SLF001
+        (
+            f"{settings._name('rule')}{code}",  # noqa: SLF001
+            registered[code].description(),
+        )
         for code in selected
     )
 
@@ -103,7 +106,7 @@ def examples(names: Iterable[str] | None = None) -> str:
         Rendered examples in selection order.
 
     """
-    name = settings._name()  # noqa: SLF001
+    rule_name = settings._name("rule")  # noqa: SLF001
     rules = {rule.code: rule for rule in registry.rules()}
     selected_codes = registry.codes() if names is None else _codes(names)
     selected = (rules[code] for code in selected_codes)
@@ -112,7 +115,7 @@ def examples(names: Iterable[str] | None = None) -> str:
         rule_examples = rule.examples()
         if rule_examples:
             groups.append(
-                f"{name}{rule.code}:\n\n" + "\n\n".join(rule_examples)
+                f"{rule_name}{rule.code}:\n\n" + "\n\n".join(rule_examples)
             )
 
     return "\n\n".join(groups)
@@ -133,8 +136,8 @@ def _codes(names: Iterable[str]) -> Iterator[int]:
         Codes in caller order.
 
     """
-    prefix = settings._name()  # noqa: SLF001
-    registered = {f"{prefix}{code}": code for code in registry.codes()}
+    rule_name = settings._name("rule")  # noqa: SLF001
+    registered = {f"{rule_name}{code}": code for code in registry.codes()}
     for name in names:
         if name not in registered:  # pragma: no cover
             raise error.RuleNameError(name)

--- a/src/lintkit/error.py
+++ b/src/lintkit/error.py
@@ -244,24 +244,34 @@ class IgnoreRangeError(LintkitError):
 
 @typing.final
 class NameMissingError(LintkitError):
-    """Raised when the linter's `lintkit.settings.name` was not set.
+    """Raised when one of the linter identities was not set.
 
     Note:
-        __Informs the linter creator__ `lintkit.settings.name` was not set,
-        as this value should be predefined before end users use the linter.
+        __Informs the linter creator__ that `lintkit.settings.name.tool` or
+        `lintkit.settings.name.rule` was not set. Both values should be
+        predefined before end users use the linter.
 
     Error output:
 
     ```python
-    Linter name missing (please set 'lintkit.settings.name' variable)
+    Linter tool name missing (please set 'lintkit.settings.name.tool' variable)
+    Linter rule name missing (please set 'lintkit.settings.name.rule' variable)
     ```
 
     """
 
-    def __init__(self) -> None:
-        """Initialize the error."""
+    def __init__(self, kind: typing.Literal["tool", "rule"]) -> None:
+        """Initialize the error.
+
+        Args:
+            kind:
+                Missing identity kind.
+
+        """
+        self.kind = kind
         self.message = (
-            "Linter name missing (please set 'lintkit.settings.name' variable)."
+            f"Linter {kind} name missing (please set "
+            f"'lintkit.settings.name.{kind}' variable)."
         )
         super().__init__(self.message)
 

--- a/src/lintkit/mcp/_server.py
+++ b/src/lintkit/mcp/_server.py
@@ -55,13 +55,14 @@ def server(
             If project rules were not imported before server construction.
 
     """
-    name = settings._name()  # noqa: SLF001
-    rule_names = tuple(f"{name}{code}" for code in registry.codes())
+    tool_name = settings._name("tool")  # noqa: SLF001
+    rule_name = settings._name("rule")  # noqa: SLF001
+    rule_names = tuple(f"{rule_name}{code}" for code in registry.codes())
     if not rule_names:
         raise error.RegistryEmptyError
     if files_reader is None:  # pragma: no branch
         files_reader = reader.Default()
-    mcp_kwargs.setdefault("name", name)
+    mcp_kwargs.setdefault("name", tool_name)
     instance = fastmcp.FastMCP(**mcp_kwargs)
     annotations = {
         "readOnlyHint": True,
@@ -78,12 +79,12 @@ def server(
         (_rules, "rules", "List rules with their descriptions."),
         (_examples, "examples", "List examples related to the rules."),
     )
-    for function, tool_name, description in tools:
+    for function, mcp_tool_name, description in tools:
         _ = instance.tool(
             _typed(function, rule_names),
-            name=tool_name,
+            name=mcp_tool_name,
             description=description,
-            tags={"lintkit", name, tool_name},
+            tags={"lintkit", tool_name, mcp_tool_name},
             annotations=annotations,
             run_in_thread=False,
         )

--- a/src/lintkit/output.py
+++ b/src/lintkit/output.py
@@ -175,7 +175,8 @@ class Output(abc.ABC):
 
         Args:
             name:
-                Name of the linter (equal to `lintkit.settings.name`).
+                Rule-identifier prefix (equal to
+                `lintkit.settings.name.rule`).
             code:
                 Numerical code of the rule.
             message:
@@ -229,7 +230,8 @@ class Stdout(Output):
 
         Args:
             name:
-                Name of the linter (equal to `lintkit.settings.name`).
+                Rule-identifier prefix (equal to
+                `lintkit.settings.name.rule`).
             code:
                 Numerical code of the rule.
             message:
@@ -273,7 +275,7 @@ class Accumulator(Output):
 
         Args:
             name:
-                Name of the linter.
+                Rule-identifier prefix.
             code:
                 Numerical rule code.
             message:
@@ -339,7 +341,8 @@ if available.RICH:
 
             Args:
                 name:
-                    Name of the linter (equal to `lintkit.settings.name`).
+                    Rule-identifier prefix (equal to
+                    `lintkit.settings.name.rule`).
                 code:
                     Numerical code of the rule.
                 message:
@@ -388,7 +391,8 @@ class JSON(Output):
 
         Args:
             name:
-                Name of the linter (equal to `lintkit.settings.name`).
+                Rule-identifier prefix (equal to
+                `lintkit.settings.name.rule`).
             code:
                 Numerical code of the rule.
             message:
@@ -432,7 +436,7 @@ def _plain(  # noqa: PLR0913, PLR0917
 
     Args:
         name:
-            Name of the linter.
+            Rule-identifier prefix.
         code:
             Numerical rule code.
         message:

--- a/src/lintkit/registry.py
+++ b/src/lintkit/registry.py
@@ -146,7 +146,7 @@ def _add(rule: type[Rule], code: int) -> None:  # pyright: ignore [reportUnusedF
     rule.code = code
     rule._ignore_line = re.compile(  # noqa: SLF001
         settings.ignore_line.format(
-            name=settings._name(),  # noqa: SLF001
+            name=settings._name("rule"),  # noqa: SLF001
             code=code,
         ),
     )

--- a/src/lintkit/rule.py
+++ b/src/lintkit/rule.py
@@ -197,7 +197,7 @@ class Rule(abc.ABC):
 
             """
             rule = self._config.config().get(
-                f"{settings._name()}{self.code}",  # noqa: SLF001
+                f"{settings._name('rule')}{self.code}",  # noqa: SLF001
                 {},
             )
             return rule.get(key, default)
@@ -374,7 +374,7 @@ class Rule(abc.ABC):
         printer(
             # This might be error prone for multiple linters defined
             # as the same package.
-            name=settings._name(),  # noqa: SLF001
+            name=settings._name("rule"),  # noqa: SLF001
             code=self.code,
             message=message,
             file=self.file,

--- a/src/lintkit/settings.py
+++ b/src/lintkit/settings.py
@@ -15,7 +15,8 @@ Example:
     ```python
     import lintkit
 
-    lintkit.settings.name = "MYLINTER"
+    lintkit.settings.name.tool = "mylinter"
+    lintkit.settings.name.rule = "MYLINTER"
 
     # Now # MYLINTER: 223 could be used to ignore error 223
     lintkit.settings.ignore_line = ".* MYLINTER: .*{name}{code}.*"
@@ -79,16 +80,33 @@ Example:
 
 from __future__ import annotations
 
+import dataclasses
+import typing
+
 from . import error
 from . import output as output_module
 
-name: str | None = None
-"""The name of the linter (`str`).
+
+@dataclasses.dataclass
+class _Name:
+    """Tool and rule identities configured by the linter creator."""
+
+    tool: str | None = None
+    rule: str | None = None
+
+
+name = _Name()
+"""The tool identity and rule-identifier prefix.
 
 Warning:
-    Has to be set before linter usage, usually
-    done at the level of `linter` module creation,
-    __not by the end user__ (user of linter).
+    Both attributes have to be set before defining concrete rules, usually at
+    the level of `linter` module creation, __not by the end user__.
+
+Attributes:
+    tool:
+        Application identity used for configuration and MCP server metadata.
+    rule:
+        Exact, case-sensitive prefix used to construct public rule identifiers.
 
 """
 
@@ -154,19 +172,26 @@ Note:
 """
 
 
-# Used internally by `rule.Rule`
-def _name() -> str:  # pyright: ignore[reportUnusedFunction]
-    """Get the linter name.
+# Used internally by lintkit consumers
+def _name(  # pyright: ignore[reportUnusedFunction]
+    kind: typing.Literal["tool", "rule"],
+) -> str:
+    """Get one configured identity.
+
+    Args:
+        kind:
+            Identity to retrieve.
 
     Returns:
-        The linter name
+        The requested identity unchanged.
 
     Raises:
-        lintkit.error.NameMissingError: If the linter name is not set.
+        lintkit.error.NameMissingError: If the requested identity is not set.
     """
-    if name is None:
-        raise error.NameMissingError
-    return name
+    value = getattr(name, kind)
+    if value is None:
+        raise error.NameMissingError(kind)
+    return value
 
 
 # Used internally by `rule.Rule`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,8 @@ import lintkit
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable
 
-lintkit.settings.name = "TEST"
+lintkit.settings.name.tool = "LINTER"
+lintkit.settings.name.rule = "TEST"
 
 REGEXES = [
     "test_run.*",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,7 +29,7 @@ def config_path(tmp_path: pathlib.Path) -> pathlib.Path:
         Path to the created configuration file.
 
     """
-    path = tmp_path / ".test.toml"
+    path = tmp_path / ".linter.toml"
     _ = path.write_text(
         """shared = "root"
 include_codes = [0, 1]

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -26,19 +26,22 @@ if typing.TYPE_CHECKING:
     from collections.abc import Iterable
 
 
-def test_name_missing(request: pytest.FixtureRequest) -> None:
-    """Ensure an error occurs when `lintkit.settings.name` is not set.
+def test_name_missing(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure an error occurs when the rule identity is not set.
 
     Args:
         request:
             Fixture request used to get the path of the test file.
+        monkeypatch:
+            Fixture used to temporarily remove the rule identity.
 
     """
-    name = lintkit.settings.name
-    lintkit.settings.name = None
+    monkeypatch.setattr(lintkit.settings.name, "rule", None)
     with pytest.raises(lintkit.error.NameMissingError):
         _ = lintkit.run([request.path])
-    lintkit.settings.name = name
 
 
 def test_incorrect_inheritance() -> None:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -70,7 +70,7 @@ def file_explicit(tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
 )
 @pytest.mark.parametrize(
     ("name_arguments", "name"),
-    (([], "TEST"), (["--name", "Custom"], "Custom")),
+    (([], "LINTER"), (["--name", "Custom"], "Custom")),
 )
 @pytest.mark.parametrize(
     ("transport_arguments", "run_arguments"),


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2025 open-nudge <https://github.com/open-nudge>
SPDX-FileContributor: szymonmaszke <github@maszke.co>

SPDX-License-Identifier: Apache-2.0
-->

<!--- pyml disable-next-line first-line-heading,first-line-h1-->

## Checklist

- [x] I agree to follow this project's [Code of Conduct](https://github.com/open-nudge/lintkit/blob/main/CODE_OF_CONDUCT.md)
- [x] I have read this project's [Contributing Guide](https://github.com/open-nudge/lintkit/blob/main/CONTRIBUTING.md)
- [x] I have created relevant issue(s) and linked them in the PR description

> Closes #35 
